### PR TITLE
Render multiple page sheets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,28 +1,29 @@
 {
-	"name": "obsidian-lily",
-	"version": "1.0.1",
-	"description": "Lilypond support in Obsidian",
-	"main": "main.js",
-	"scripts": {
-		"dev": "node esbuild.config.mjs",
-		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-		"version": "node version-bump.mjs && git add manifest.json versions.json"
-	},
-	"keywords": [],
-	"author": "Dot-Asterisk",
-	"license": "MIT",
-	"devDependencies": {
-		"@types/node": "^16.11.6",
-		"@types/temp": "^0.9.1",
-		"@typescript-eslint/eslint-plugin": "^5.2.0",
-		"@typescript-eslint/parser": "^5.2.0",
-		"builtin-modules": "^3.2.0",
-		"esbuild": "0.13.12",
-		"obsidian": "latest",
-		"tslib": "2.3.1",
-		"typescript": "4.4.4"
-	},
-	"dependencies": {
-		"temp": "^0.9.4"
-	}
+  "name": "obsidian-lily",
+  "version": "1.0.1",
+  "description": "Lilypond support in Obsidian",
+  "main": "main.js",
+  "scripts": {
+    "dev": "node esbuild.config.mjs",
+    "build": "./node_modules/typescript/bin/tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+    "version": "node version-bump.mjs && git add manifest.json versions.json"
+  },
+  "keywords": [],
+  "author": "Dot-Asterisk",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^16.11.6",
+    "@types/temp": "^0.9.1",
+    "@typescript-eslint/eslint-plugin": "^5.2.0",
+    "@typescript-eslint/parser": "^5.2.0",
+    "builtin-modules": "^3.2.0",
+    "esbuild": "0.13.12",
+    "obsidian": "latest",
+    "tslib": "2.3.1",
+    "typescript": "4.4.4"
+  },
+  "dependencies": {
+    "pdf2html": "^3.1.0",
+    "temp": "^0.9.4"
+  }
 }

--- a/src/lilypond.ts
+++ b/src/lilypond.ts
@@ -23,17 +23,26 @@ export const render = async function (
 	const lyFileDir = path.join(lyFile.path, "..");
 	try {
 		await exec(`${lilypondPath} -dbackend=svg -dpoint-and-click=false -fsvg --silent --output=${lyFileDir} ${lyFile.path}`)
-		sleep(1)
+
 		const outputPaths = collectFiles(lyFile.path)
-		const html = outputPaths
-			.map((path) => fs.readFileSync(path, { encoding: "utf8", flag: "r" }))
-			.join("<br/><br/>")
-		el.innerHTML = html
+
+		const htmls = await renderSvgs(outputPaths)
+
+		el.innerHTML = htmls.join("<br/><br/>")
 	} catch (error) {
 		console.error(error);
 		renderError(error, el)
 	}
 };
+
+const renderSvgs = async (files: string[]): Promise<string[]> => {
+	const htmls = await Promise.all(
+		files.map(
+			(path) => fs.promises.readFile(path, { encoding: "utf8", flag: "r" }),
+		),
+	)
+	return htmls
+}
 
 const collectFiles = (lyFilePath: string): string[] => {
 	const fileNameNoExt = path.join(path.dirname(lyFilePath), path.basename(lyFilePath, '.ly'))


### PR DESCRIPTION
Hey!

Awesome plugin, exactly what I was looking for!

I had an issue rendering multi-page drum sheets — it just couldn't find the output file, cause lilypond generates multiple files in that case with a slightly different naming. I added multi-page rendering with this PR